### PR TITLE
Add placeholder for url of the page where the feedback was submitted #14

### DIFF
--- a/action.php
+++ b/action.php
@@ -24,7 +24,6 @@ class action_plugin_feedback extends DokuWiki_Action_Plugin {
      */
     public function register(Doku_Event_Handler $controller) {
 
-        $controller->register_hook('DOKUWIKI_STARTED', 'BEFORE', $this, 'handle_start');
         $controller->register_hook('AJAX_CALL_UNKNOWN', 'BEFORE', $this, 'handle_ajax');
         $controller->register_hook('DETAIL_STARTED', 'BEFORE', $this, 'handle_detail_started');
     }
@@ -45,22 +44,6 @@ class action_plugin_feedback extends DokuWiki_Action_Plugin {
         if(!$this->getFeedbackContact($ID)) return false;
 
         return true;
-    }
-
-    /**
-     * Add some info about the current page to the info array if feedback can be given
-     *
-     * @param Doku_Event $event  event object by reference
-     * @param mixed $param  [the parameters passed as fifth argument to register_hook() when this
-     *                           handler was registered]
-     * @return void
-     */
-    public function handle_start(Doku_Event &$event, $param) {
-        global $JSINFO;
-
-        if(!$this->feedback_possible()) return;
-
-        $JSINFO['plugin_feedback'] = true;
     }
 
     /**

--- a/action.php
+++ b/action.php
@@ -72,6 +72,7 @@ class action_plugin_feedback extends DokuWiki_Action_Plugin {
         global $INPUT;
         $id = $INPUT->str('id');
         $feedback = $INPUT->str('feedback');
+        $media = $INPUT->bool('media');
 
         // get the responsible contact
         $contact = $this->getFeedbackContact($id);
@@ -94,9 +95,10 @@ class action_plugin_feedback extends DokuWiki_Action_Plugin {
         $mailer->to($contact);
         if($user) $mailer->setHeader('Reply-To', $user['mail']);
         $mailer->subject($this->getLang('subject'));
+        $ml_or_wl = $media ? 'ml' : 'wl';
         $mailer->setBody(
             io_readFile($this->localFN('mail')),
-            array('PAGE' => $id, 'FEEDBACK' => $feedback)
+            array('PAGE' => $id, 'FEEDBACK' => $feedback, 'URL' => $ml_or_wl($id))
         );
         $success = $mailer->send();
         header('Content-Type: text/html; charset=utf-8');

--- a/action.php
+++ b/action.php
@@ -94,10 +94,14 @@ class action_plugin_feedback extends DokuWiki_Action_Plugin {
         $mailer->to($contact);
         if($user) $mailer->setHeader('Reply-To', $user['mail']);
         $mailer->subject($this->getLang('subject'));
-        $ml_or_wl = $media ? 'ml' : 'wl';
+        if ($media) {
+            $url = ml($id, '', false, '&amp;', true);
+        } else {
+            $url = wl($id, '', true);
+        }
         $mailer->setBody(
             io_readFile($this->localFN('mail')),
-            array('PAGE' => $id, 'FEEDBACK' => $feedback, 'URL' => $ml_or_wl($id))
+            array('PAGE' => $id, 'FEEDBACK' => $feedback, 'URL' => $url)
         );
         $success = $mailer->send();
         header('Content-Type: text/html; charset=utf-8');

--- a/script.js
+++ b/script.js
@@ -6,7 +6,7 @@ jQuery(function () {
 
             var getPageId = function() {
                 //JSINFO avalible in doku.php
-                if (JSINFO && JSINFO.id) return JSINFO.id;
+                if (JSINFO) return JSINFO.id;
 
                 //JSINFO not avalible in detail.php
                 var media_id = window.location.href.match(/media=([^&#]*)/)[1];
@@ -60,7 +60,8 @@ jQuery(function () {
                                 {
                                     call: 'plugin_feedback',
                                     feedback: text,
-                                    id: getPageId()
+                                    id: getPageId(),
+                                    media: JSINFO ? '0' : '1'
                                 },
                                 // display thank you message
                                 function (result) {

--- a/script.js
+++ b/script.js
@@ -1,9 +1,17 @@
 jQuery(function () {
-    if (!JSINFO.plugin_feedback) return;
     jQuery('.plugin_feedback')
         .show()
         .click(function (e) {
             e.preventDefault();
+
+            var getPageId = function() {
+                //JSINFO avalible in doku.php
+                if (JSINFO && JSINFO.id) return JSINFO.id;
+
+                //JSINFO not avalible in detail.php
+                var media_id = window.location.href.match(/media=([^&#]*)/)[1];
+                return media_id;
+            };
 
             // create the dialog frame
             var $dialog = jQuery(
@@ -52,7 +60,7 @@ jQuery(function () {
                                 {
                                     call: 'plugin_feedback',
                                     feedback: text,
-                                    id: JSINFO.id
+                                    id: getPageId()
                                 },
                                 // display thank you message
                                 function (result) {


### PR DESCRIPTION
Now the `@URL@` placeholder is replaced with the absolute URL of wiki page or media detail. 

douwiki's Mailer while outputting html, changes all URLs into <a> links, so placing the `@URL@` in mail.txt results: `<a href="URL">URL</a>`