### PR TITLE
Add language files for de-informal

### DIFF
--- a/lang/de-informal/intro.txt
+++ b/lang/de-informal/intro.txt
@@ -1,0 +1,5 @@
+====== Feedback Manager festlegen ======
+
+Über dieses Formular kannst du die E-Mail-Adressen der Feedback-Veratwortlichen für bestimmte Namensräume festlegen.
+
+Zugewiesene E-Mail-Adressen gelten automatisch auch für Unternamensräume. Du kannst mehrere Adressen kommagetrennt angeben. Um den Wurzel-Namensraum festzulegen, nutze bitte ein Sternchen ''*''.

--- a/lang/de-informal/lang.php
+++ b/lang/de-informal/lang.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * de-informal language file for feedback plugin
+ *
+ * @author Volker Bürckel <volker@vrbdev.eu>
+ */
+
+$lang['menu']         = 'Feedback-Verantwortliche festlegen';
+
+$lang['feedback']     = 'Feedback geben';
+$lang['subject']      = 'Feedback';
+$lang['thanks']       = 'Vielen Dank für deine Unterstützung!';
+$lang['error']        = 'Leider ist ein Fehler aufgetreten und dein Feedback konnte nicht gesendet werden.';
+
+$lang['namespace']    = 'Namensraum';
+$lang['email']        = 'E-Mail';
+$lang['save']         = 'Speichern';
+$lang['saved']        = 'Deine Feedback-Verantwortlichen wurden gespeichert';
+
+$lang['js']['title']  = 'Schreibe hier dein Feedback';
+$lang['js']['cancel'] = 'Abbrechen';
+$lang['js']['close']  = 'Schließen';
+$lang['js']['submit'] = 'Senden';

--- a/lang/de-informal/mail.txt
+++ b/lang/de-informal/mail.txt
@@ -1,0 +1,5 @@
+Jemand hat Feedback zu deiner Seite @PAGE@ gesendet. Hier sind die Details:
+
+@FEEDBACK@
+
+Gesendet von: @USER@

--- a/lang/de-informal/settings.php
+++ b/lang/de-informal/settings.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * de-informal language file for feedback plugin
+ *
+ * @author Volker Bürckel <volker@vrbdev.eu>
+ */
+
+$lang['allowanon'] = 'Nicht angemeldeten Nutzenden das Senden von Feedback ermöglichen';
+$lang['include_parent_startpage'] = 'Die Startseite zählt auch dann zu einem Namensraum wenn sie oberhalb dessen liegt';
+$lang['span_translations'] = 'Feedback-Verantwortliche erhalten das Feedback aller Übersetzungen ihres Namensraumes (erfordert das translation-plugin)';
+$lang['send_copy'] = 'Feedback-Gebenden eine Kopie ihres Feedbacks zusenden (nur für angemeldete Nutzende)';


### PR DESCRIPTION
The user related language files could be added by using conf/plugin_lang/feedback/de-informal, but this doesn't work for admin related langiage file settings.php. So add de-informal here.