### PR TITLE
Add possibility to extend feedback form and mail text by user defined fields.

### DIFF
--- a/action.php
+++ b/action.php
@@ -80,7 +80,7 @@ class action_plugin_feedback extends DokuWiki_Action_Plugin {
         // only on show and detail pages
         if($ACT != 'show' && !$this->detail_page) return false;
         // allow anonymous feedback?
-        if(!$_SERVER['REMOTE_USER'] && !$this->getConf('allowanon')) return false;
+        if(!isset($_SERVER['REMOTE_USER']) && !$this->getConf('allowanon')) return false;
         // any contact defined?
         if(!$this->getFeedbackContact($ID)) return false;
 
@@ -103,7 +103,7 @@ class action_plugin_feedback extends DokuWiki_Action_Plugin {
         $event->stopPropagation();
 
         // allow anonymous feedback?
-        if(!$_SERVER['REMOTE_USER'] && !$this->getConf('allowanon')) {
+        if(!isset($_SERVER['REMOTE_USER']) && !$this->getConf('allowanon')) {
             http_status(400);
             die('no anonymous access');
         }
@@ -127,7 +127,7 @@ class action_plugin_feedback extends DokuWiki_Action_Plugin {
 
         // get info on user
         $user = null;
-        if($_SERVER['REMOTE_USER']) {
+        if(isset($_SERVER['REMOTE_USER'])) {
             /** @var DokuWiki_Auth_Plugin $auth */
             global $auth;
             $user = $auth->getUserData($_SERVER['REMOTE_USER']);

--- a/action.php
+++ b/action.php
@@ -4,12 +4,26 @@
  *
  * @license GPL 2 http://www.gnu.org/licenses/gpl-2.0.html
  * @author  Andreas Gohr <gohr@cosmocode.de>
+ * 
+ * Additional Fields (@FEEBACK_...@):
+ * @author Volker Bürckel <volker@vrbdev.eu>
  */
 
 // must be run within Dokuwiki
 if(!defined('DOKU_INC')) die();
 
+use dokuwiki\Logger;
+
 class action_plugin_feedback extends DokuWiki_Action_Plugin {
+
+    /** 
+     * Path to feedback plugin's original script.js file.
+     */
+    const OLD_SCRIPT = DOKU_PLUGIN . 'feedback/script.js';
+    /** 
+     * Path to replacement script.js file to extend the feedback form.
+     */
+    const NEW_SCRIPT = DOKU_CONF . 'plugin_feedback.script.js';
 
     /*
      * @var true if we are on the detail page
@@ -27,6 +41,32 @@ class action_plugin_feedback extends DokuWiki_Action_Plugin {
         $controller->register_hook('AJAX_CALL_UNKNOWN', 'BEFORE', $this, 'handle_ajax');
         $controller->register_hook('DETAIL_STARTED', 'BEFORE', $this, 'handle_detail_started');
         $controller->register_hook('DOKUWIKI_STARTED', 'BEFORE', $this, 'handleDokuStarted');
+        // Use JS_SCRIPT_LIST to replace original script.js by extended one
+        $controller->register_hook('JS_SCRIPT_LIST', 'AFTER', $this, 'handleJsScriptList');
+    }
+
+    /**
+     * Event handler for JS_SCRIPT_LIST
+     * 
+     * If we have a plugin_feedback.script.js in DOKU_CONF, replace the original
+     * script DOKU_PLUGIN/feedback/script.js by this file.
+     *
+     * @see https://www.dokuwiki.org/devel:events:JS_SCRIPT_LIST
+     * @param Doku_Event $event Event object, $event->data holds the list
+     * @param mixed $param optional parameter passed when event was registered
+     * @return void
+     */
+    public function handleJsScriptList(Doku_Event $event, $param)
+    {
+        if (file_exists(self::NEW_SCRIPT)) {
+            foreach ($event->data as $key => $entry) {
+                if ($entry == self::OLD_SCRIPT) {
+                    $event->data[$key] = self::NEW_SCRIPT;
+                    Logger::debug('feedback: using ' . self::NEW_SCRIPT);
+                    break;
+                }
+            }
+        }
     }
 
     /**
@@ -73,6 +113,10 @@ class action_plugin_feedback extends DokuWiki_Action_Plugin {
         $id = $INPUT->str('id');
         $feedback = $INPUT->str('feedback');
         $media = $INPUT->bool('media');
+        // User defined fields start with "FEEDBACK_"
+        $req_fields = array_filter($_REQUEST, function ($key) { 
+            return str_starts_with($key, "FEEDBACK_");
+        }, ARRAY_FILTER_USE_KEY);
 
         // get the responsible contact
         $contact = $this->getFeedbackContact($id);
@@ -102,7 +146,7 @@ class action_plugin_feedback extends DokuWiki_Action_Plugin {
         }
         $mailer->setBody(
             io_readFile($this->localFN('mail')),
-            array('PAGE' => $id, 'FEEDBACK' => $feedback, 'URL' => $url),
+            array_merge(array('PAGE' => $id, 'FEEDBACK' => $feedback, 'URL' => $url), $req_fields),
             array('FEEDBACK' => nl2br($feedback))
         );
         $success = $mailer->send();
@@ -165,7 +209,7 @@ class action_plugin_feedback extends DokuWiki_Action_Plugin {
     }
 
     /**
-     * Get the responsible contact for givven ID
+     * Get the responsible contact for given ID
      *
      * @param $id
      * @return false|string

--- a/local_script/README
+++ b/local_script/README
@@ -1,0 +1,18 @@
+The files in this directory help you to extend the feedback dialog and mail.
+
+To extend the feedback dialog to more than just a single text area, do the following:
+
+(1) Script:
+Design your input dialog using the script.js file in this directory as a template. Doing so, add any additional data that you want to use in the feedback mail to the POST result by using names starting with "FEEDBACK_" (see sample FEEDBACK_NAME in script.js). 
+
+Copy your script file to [DOKUWIKI BASE]/conf/plugin_feedback.script.js OR use the jstweak plugin (https://www.dokuwiki.org/plugin:jstweak) to replace the plugin's original script.js by your own script file. 
+
+(2) Localization:
+If you use localized text like e.g. placeholder texts, declare them in lang.php. 
+  Example: $lang['js']['placeholder_name'] = "Name";
+Note that you don't need to modify the original lang.php in the [DOKUWIKI BASE]/lib/plugins/feedback/lang but rather create a new file [DOKUWIKI BASE]/conf/plugin_lang/feedback/<language>/lang.php for your extensions (see https://www.dokuwiki.org/plugin:feedback). 
+
+Create a new mail.txt file using your new variable, e.g. @FEEDBACK_NAME@. mail.txt can also be placed in [DOKUWIKI BASE]/conf/plugin_lang/feedback/<language>/.
+
+Hint:
+You find a sample lang.php and a sample mail.txt in this directory as well, which you can copy to [DOKUWIKI BASE]/conf/plugin_lang/feedback/en/.

--- a/local_script/lang.php
+++ b/local_script/lang.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Sample en language file for additional feedback plugin fields.
+ * Shall be put in [DOKUWIKI BASE]/conf/plugin_lang/feedback/en/
+ *
+ * @author Volker Bürckel <volker@vrbdev.eu>
+ */
+
+$lang['js']['placeholder_name']     = 'Your name';
+$lang['js']['placeholder_feedback'] = 'Your feedback';

--- a/local_script/mail.txt
+++ b/local_script/mail.txt
@@ -1,0 +1,10 @@
+Someone has sent feedback. You find the details here:
+
+Page: @PAGE@
+Date/Time: @DATE@
+User: @USER@
+Name: @FEEDBACK_NAME@
+
+Feedback text:
+
+@FEEDBACK@

--- a/local_script/script.js
+++ b/local_script/script.js
@@ -1,0 +1,120 @@
+/**
+ * Example script.js with an additional field for the name
+ * of the person giving feedback. See README in this folder
+ * to understand what to do with it.
+ * 
+ * This script extends the original script.js of the plugin.
+ */
+
+jQuery(function () {
+
+    // return value if defined, empty string otherwise
+    function get_variable_safe(value) {
+        if (typeof value === 'undefined') {
+            return '---';
+        }
+        return value;
+    }
+
+    jQuery('.plugin_feedback')
+        .show()
+        .click(function (e) {
+            e.preventDefault();
+
+            var getPageId = function() {
+                if (window.JSINFO.plugins.feedback.isMedia) {
+                    return window.JSINFO.plugins.feedback.mediaID;
+                }
+                return window.JSINFO.id;
+            };
+
+            // create the dialog frame
+            var $dialog = jQuery(
+                '<div>' +
+                    '<form>' +
+                        // EXTENSION (part 1/3):
+                        // insert "name" field: we insert an additional field
+                        // which can be found by its name in part 2 (see below)
+                        '<input type="text" name="name" placeholder="' +
+                            // a placeholder will be displayed if found in lang.php
+                            // (here i.e.: $lang['js']['placeholder_name'] = "Name";)
+                            get_variable_safe(LANG.plugins.feedback.placeholder_name) +
+                        '"; style="width:100%; margin-bottom:8px;">' +
+                        '<textarea placeholder="' +
+                            // another placeholder for the feedback text area
+                            get_variable_safe(LANG.plugins.feedback.placeholder_feedback) +
+                        '"; style="width:100%; height:150px;"></textarea>' +
+                    '</form>' +
+                '</div>'
+            );
+
+            // initialize the dialog functionality
+            $dialog.dialog({
+                title: LANG.plugins.feedback.title,
+                width: 600,
+                height: 350,
+                dialogClass: 'plugin_feedbackdialog',
+                buttons: [
+                    {
+                        text: LANG.plugins.feedback.cancel,
+                        click: function () {
+                            $dialog.dialog("close");
+                        }
+                    },
+                    {
+                        text: LANG.plugins.feedback.submit,
+                        click: function () {
+                            var self = this;
+
+                            // EXTENSION (part 2/3):
+                            // insert "name" field: store its contents in a
+                            // variable called "name" for later use (see below)
+                            var name = $dialog.find('input[name="name"]').val();
+                            var text = $dialog.find('textarea').val();
+
+                            if (!text) return;
+
+                            // switch button set and empty form
+                            $dialog.html('');
+                            $dialog.dialog('option', 'buttons',
+                                [
+                                    {
+                                        text: LANG.plugins.feedback.close,
+                                        click: function () {
+                                            $dialog.dialog("close");
+                                        }
+                                    }
+                                ]
+                            );
+
+                            // post the data
+                            jQuery.post(
+                                DOKU_BASE + 'lib/exe/ajax.php',
+                                {
+                                    call: 'plugin_feedback',
+                                    feedback: text,
+                                    // EXTENSION (part 3/3):
+                                    // insert "name" field: we use the name "FEEDBACK_NAME"
+                                    // to POST our new field, since any field starting with 
+                                    // "FEEDBACK_" in the POST result can be addressed 
+                                    // later on in mail.txt using "@FEEDBACK_...@" 
+                                    // (here: "@FEEDBACK_NAME@")
+                                    FEEDBACK_NAME: name, // 👈 NEU
+                                    id: getPageId(),
+                                    media: !!window.JSINFO.plugins.feedback.isMedia
+                                },
+                                // display thank you message
+                                function (result) {
+                                    $dialog.html(result);
+                                }
+                            );
+                        }
+                    }
+                ],
+                // remove HTML from DOM again
+                close: function () {
+                    jQuery(this).remove();
+                }
+            });
+        });
+});

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   feedback
 author Andreas Gohr
 email  gohr@cosmocode.de
-date   2019-03-21
+date   2026-01-28
 name   feedback plugin
 desc   Integrate a feedback tool into DokuWiki
 url    http://www.dokuwiki.org/plugin:feedback


### PR DESCRIPTION
Add possibility to extend feedback form and mail text by user defined fields. Sample files and README can be found in local_script/. 

Fixes #4